### PR TITLE
Make list width to be 100% instead of dynamic

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -472,10 +472,6 @@ const languagePromise = fetch(
                 input.size = Math.max(input.value.length, 10);
                 input.idx_suggestion = 0;
 
-                if (list) {
-                    list.style.width = `${input.offsetWidth}px`;
-                }
-
                 input.focus();
 
                 input.addEventListener("keypress", e => {
@@ -489,7 +485,6 @@ const languagePromise = fetch(
 
                 input.addEventListener("input", () => {
                     input.size = Math.max(10, input.value.length);
-                    list.style.width = `${input.offsetWidth}px`;
                 });
 
                 form.addEventListener("submit", function _submit_form(e) {
@@ -511,7 +506,6 @@ const languagePromise = fetch(
                         list.classList.add('close');
                         input.value = e.target.textContent;
                         input.size = input.value.length;
-                        list.style.width = `${input.offsetWidth}px`;
 
                         resolve(result);
                     }
@@ -529,7 +523,6 @@ const languagePromise = fetch(
                             list.classList.add('close');
                             input.value = e.target.textContent;
                             input.size = input.value.length;
-                            list.style.width = `${input.offsetWidth}px`;
 
                             resolve(result);
                         }

--- a/extension/main.css
+++ b/extension/main.css
@@ -241,6 +241,7 @@
     position: absolute;
     transform-origin: top;
     transform: scaleY(0);
+    width: 100%;
 }
 
 #stm-list.close {


### PR DESCRIPTION
Instead of setting the list width in JavaScript, make it 100% in the CSS file, so it adapts to the wrapper element and always matches the <input> field width.

Fixes #129 and simplifies the code.